### PR TITLE
SSV & SSV2 - null string args

### DIFF
--- a/src/plugins/Form/Validation/SSV.php
+++ b/src/plugins/Form/Validation/SSV.php
@@ -262,6 +262,9 @@ class SSV
 
                 case 'is_date':
                     $regex = '/^\d{1,2}\/\d{1,2}\/\d{4}$/';
+                    if (is_null($var_val1)) {
+                        $var_val1 = '';
+                    }
                     $vr = preg_match($regex, $var_val1);
                     if (strlen($var_val1) > 10) { $vr = false; }
                     break;

--- a/src/plugins/Form/Validation/SSV2.php
+++ b/src/plugins/Form/Validation/SSV2.php
@@ -369,6 +369,9 @@ class SSV2
 
             case 'is_date':
                 $regex = '/^\d{1,2}\/\d{1,2}\/\d{4}$/';
+                if (is_null($var_val1)) {
+                    $var_val1 = '';
+                }
                 $vr = preg_match($regex, $var_val1);
                 if (strlen($var_val1) > 10) { $vr = false; }
                 break;


### PR DESCRIPTION
Starting with PHP 8.1, deprecation warnings are emitted when passing null to non-nullable arguments of internal functions.  I have tried to correct this while maintaining the PHP version compatibility of the framework.