### PR TITLE
Fix incorrect check for failed_login_function

### DIFF
--- a/src/plugins/Framework/App/Security/Login.php
+++ b/src/plugins/Framework/App/Security/Login.php
@@ -101,7 +101,7 @@ class Login
     //*************************************************************************
     private function fail_login($msg)
     {
-        if (isset($_SESSION['failed_login_function']) && function_exists($_SESSION['failed_login_function'])) {
+        if (isset($_SESSION['failed_login_function']) && is_callable($_SESSION['failed_login_function'])) {
             $fail_ret_val = call_user_func($_SESSION['failed_login_function']);
         }
         else if (function_exists('failed_login')) {


### PR DESCRIPTION
The check for $_SESSION['failed_login_function'] should use is_callable similar to the check in \phpOpenFW\Framework\App\Security\Authentication for custom_login_function